### PR TITLE
remove type hinting in constructor method for Process and Queue

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -58,11 +58,11 @@ class Process
     /**
      * Process constructor.
      * @param $name
-     * @param callable $callback
+     * @param $callback
      * @param bool $stdout
      * @param bool $pipe
      */
-    public function __construct($name = null, callable $callback = null, $stdout = false, $pipe = true)
+    public function __construct($name = null, $callback = null, $stdout = false, $pipe = true)
     {
         $this->name = $name;
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -19,11 +19,11 @@ class Queue extends Process
     /**
      * Queue constructor.
      * @param $name
-     * @param callable $callback
+     * @param $callback
      * @param bool $stdout
      * @param bool $pipe
      */
-    public function __construct($name, callable $callback, $stdout = false, $pipe = true)
+    public function __construct($name, $callback, $stdout = false, $pipe = true)
     {
         parent::__construct($name, $callback, $stdout, $pipe);
 


### PR DESCRIPTION
取消 Process 跟 Queue 构造方法中的 `$callback` 的类型约束, 从而支持传递函数名或类方法